### PR TITLE
switch wallet to right chain on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
 The Rico amount is *approximate*.  It depends on the rate accumulator when the transaction executes.
 </p>
 <p style="justify-content:center;">
-If time since last rate accumulator update is high, try borrowing 0 or paying 0 first to update it, and refresh the page.  The Rico amount then will be closer to the true amount minted or burned.
+If time since last rate accumulator update is high, try borrowing 0 or paying 0 first to update it.  The Rico amount then will be closer to the true amount minted or burned.
 </p>
 <p style="justify-content:center;">
 This page is designed to be saved (as in "File > Save") and be usable even if DNS or this web host go offline or are compromised.

--- a/main.js
+++ b/main.js
@@ -496,10 +496,12 @@ window.onload = async() => {
         });
     });
 
-    // todo update on palms
-
-    await Promise.all([updateRicoStats(), updateHook()]);
     await walletClient.switchChain({ id: sepolia.id })
+    await Promise.all([updateRicoStats(), updateHook()])
+    bank.watchEvent.NewFlog(
+        { caller: account },
+        { async onLogs(logs) { await Promise.all([updateRicoStats(), updateHook()]) } }
+    )
 }
 
 const maxBigInt = (a, b) => a > b ? a : b


### PR DESCRIPTION
consistent uni checkbox display order
tooltip to clarify "all debt" rather than "all account balance"